### PR TITLE
Allow for metaclasses that override truthiness

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.6.2
+======
+
+#3 and bpo-23572: Fix behavior when metaclass implements bool.
+
 v3.6.1
 ======
 

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -36,7 +36,7 @@ def _c3_merge(sequences):
                     break      # reject the current head, it appears later
             else:
                 break
-        if not candidate:
+        if candidate is None:
             raise RuntimeError("Inconsistent hierarchy")
         result.append(candidate)
         # remove the chosen candidate

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -293,6 +293,24 @@ class TestSingleDispatch(unittest.TestCase):
         many_abcs = [c.Mapping, c.Sized, c.Callable, c.Container, c.Iterable]
         self.assertEqual(mro(X, abcs=many_abcs), expected)
 
+    def test_false_meta(self):
+        # see issue23572
+        class MetaA(type):
+            def __len__(self):
+                return 0
+        class A(metaclass=MetaA):
+            pass
+        class AA(A):
+            pass
+        @functools.singledispatch
+        def fun(a):
+            return 'base A'
+        @fun.register(A)
+        def _(a):
+            return 'fun A'
+        aa = AA()
+        self.assertEqual(fun(aa), 'fun A')
+
     def test_mro_conflicts(self):
         c = coll_abc
         @functools.singledispatch

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -298,8 +298,15 @@ class TestSingleDispatch(unittest.TestCase):
         class MetaA(type):
             def __len__(self):
                 return 0
-        class A(metaclass=MetaA):
-            pass
+        if sys.version_info < (3,):
+            class A(object):
+                __metaclass__ = MetaA
+        else:
+            """
+            class A(metaclass=MetaA):
+                pass
+            """
+            A = MetaA('A', (), {})
         class AA(A):
             pass
         @functools.singledispatch


### PR DESCRIPTION
Alters how we test candidates to take account that a type might have override its truth value.  A similar fix was made in core python in response to https://bugs.python.org/issue23572.

The code change here reflects that [fix](https://hg.python.org/cpython/rev/586195685aaf) in `_c3_merge`.

#### Note ####

This has been a long standing issue in the backport, and had been reported as an issue prior to moving to GitHub.