### PR TITLE
Add backport for singledispatchmethod

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v3.7.0
+======
+
+#4: Add ``singledispatchmethod`` from Python 3.8.
+
+Incorporate minor changes from Python 3.8.
+
 v3.6.2
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ This library is a backport of this functionality and its evolution.
 Refer to the `upstream documentation
 <http://docs.python.org/3/library/functools.html#functools.singledispatch>`_
 for API guidance. To use the backport, simply use
-``from singledispatch import singledispatch`` in place of
-``from functools import singledispatch``.
+``from singledispatch import singledispatch, singledispatchmethod`` in place of
+``from functools import singledispatch, singledispatchmethod``.
 
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ testing =
 	#pytest-enabler >= 1.0.1
 
 	# local
-	unittest2; python_version < "2.7"
+	unittest2; python_version <= "2.7"
 
 docs =
 	# upstream

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ testing =
 	#pytest-enabler >= 1.0.1
 
 	# local
-	unittest2; python_version <= "2.7"
+	unittest2; python_version < "3"
 
 docs =
 	# upstream

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -173,7 +173,7 @@ def _validate_annotation(func):
     try:
         # In Python 3.5 and 3.6, the classes in typing are considered instances
         # of type, but they aren't valid for registering single dispatch
-        # functions so we need to check against TypingMeta instead
+        # functions so we need to check against GenricMeta instead
         from typing import GenericMeta
         valid = not isinstance(cls, GenericMeta)
     except ImportError:

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ['singledispatch']
+__all__ = ['singledispatch', 'singledispatchmethod']
 
 from weakref import WeakKeyDictionary
 

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -246,3 +246,39 @@ def singledispatch(func):
     update_wrapper(wrapper, func)
     return wrapper
 
+
+# Descriptor version
+class singledispatchmethod:
+    """Single-dispatch generic method descriptor.
+
+    Supports wrapping existing descriptors and handles non-descriptor
+    callables as instance methods.
+    """
+
+    def __init__(self, func):
+        if not callable(func) and not hasattr(func, "__get__"):
+            raise TypeError("{!r} is not callable or a descriptor".format(func))
+
+        self.dispatcher = singledispatch(func)
+        self.func = func
+
+    def register(self, cls, method=None):
+        """generic_method.register(cls, func) -> func
+
+        Registers a new implementation for the given *cls* on a *generic_method*.
+        """
+        return self.dispatcher.register(cls, func=method)
+
+    def __get__(self, obj, cls=None):
+        def _method(*args, **kwargs):
+            method = self.dispatcher.dispatch(args[0].__class__)
+            return method.__get__(obj, cls)(*args, **kwargs)
+
+        _method.__isabstractmethod__ = self.__isabstractmethod__
+        _method.register = self.register
+        update_wrapper(_method, self.func)
+        return _method
+
+    @property
+    def __isabstractmethod__(self):
+        return getattr(self.func, '__isabstractmethod__', False)

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -164,6 +164,24 @@ def _find_impl(cls, registry):
             match = t
     return registry.get(match)
 
+def _validate_annotation(func):
+    """Determine if an annotation is valid for registration.
+
+    An annotation is considered valid for use in registration if it is an
+    instance of ``type`` and not a generic type from ``typing``.
+    """
+    argname, cls = next(iter(get_type_hints(func).items()))
+    try:
+        # In Python 3.5 and 3.6, the classes in typing are considered instances
+        # of type, but they aren't valid for registering single dispatch
+        # functions so we need to check against TypingMeta instead
+        from typing import GenericMeta
+        valid = not isinstance(cls, GenericMeta)
+    except ImportError:
+        # In Python 3.7+, classes in typing are not instances of type
+        valid = isinstance(cls, type)
+    return argname, cls, valid
+
 def singledispatch(func):
     """Single-dispatch generic function decorator.
 
@@ -217,9 +235,8 @@ def singledispatch(func):
                     "on an annotated function.".format(**locals())
                 )
             func = cls
-
-            argname, cls = next(iter(get_type_hints(func).items()))
-            if not isinstance(cls, type) or hasattr(cls, '_gorg'):
+            argname, cls, valid = _validate_annotation(func)
+            if not valid:
                 raise TypeError(
                     "Invalid annotation for {argname!r}. "
                     "{cls!r} is not a class.".format(**locals())

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -264,7 +264,7 @@ def singledispatch(func):
 
 
 # Descriptor version
-class singledispatchmethod:
+class singledispatchmethod(object):
     """Single-dispatch generic method descriptor.
 
     Supports wrapping existing descriptors and handles non-descriptor

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -219,7 +219,7 @@ def singledispatch(func):
             func = cls
 
             argname, cls = next(iter(get_type_hints(func).items()))
-            if not isinstance(cls, type):
+            if not isinstance(cls, type) or hasattr(cls, '_gorg'):
                 raise TypeError(
                     "Invalid annotation for {argname!r}. "
                     "{cls!r} is not a class.".format(**locals())

--- a/singledispatch/__init__.py
+++ b/singledispatch/__init__.py
@@ -8,10 +8,9 @@ from __future__ import unicode_literals
 
 __all__ = ['singledispatch']
 
-from functools import update_wrapper
 from weakref import WeakKeyDictionary
 
-from .helpers import MappingProxyType, get_cache_token, get_type_hints
+from .helpers import MappingProxyType, get_cache_token, get_type_hints, update_wrapper
 
 ################################################################################
 ### singledispatch() - single-dispatch generic function decorator

--- a/singledispatch/helpers.py
+++ b/singledispatch/helpers.py
@@ -181,3 +181,37 @@ def get_type_hints(func):
     # only import typing if annotation parsing is necessary
     from typing import get_type_hints
     return get_type_hints(func) or getattr(func, '__annotations__', {})
+
+
+WRAPPER_ASSIGNMENTS = ('__module__', '__name__', '__qualname__', '__doc__',
+                       '__annotations__')
+WRAPPER_UPDATES = ('__dict__',)
+def update_wrapper(wrapper,
+                   wrapped,
+                   assigned = WRAPPER_ASSIGNMENTS,
+                   updated = WRAPPER_UPDATES):
+    """Update a wrapper function to look like the wrapped function
+
+       wrapper is the function to be updated
+       wrapped is the original function
+       assigned is a tuple naming the attributes assigned directly
+       from the wrapped function to the wrapper function (defaults to
+       functools.WRAPPER_ASSIGNMENTS)
+       updated is a tuple naming the attributes of the wrapper that
+       are updated with the corresponding attribute from the wrapped
+       function (defaults to functools.WRAPPER_UPDATES)
+    """
+    for attr in assigned:
+        try:
+            value = getattr(wrapped, attr)
+        except AttributeError:
+            pass
+        else:
+            setattr(wrapper, attr, value)
+    for attr in updated:
+        getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
+    # Issue #17482: set __wrapped__ last so we don't inadvertently copy it
+    # from the wrapped function when updating __dict__
+    wrapper.__wrapped__ = wrapped
+    # Return the wrapper so this can be used as a decorator via partial()
+    return wrapper

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -581,8 +581,8 @@ class TestSingleDispatch(unittest.TestCase):
 
         # Registering classes as callables doesn't work with annotations,
         # you need to pass the type explicitly.
-        @i.register(six.text_type)
-        class _(object):
+        @i.register(str)
+        class _:
             def __init__(self, arg):
                 self.arg = arg
 

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -748,6 +748,7 @@ class TestSingleDispatch(unittest.TestCase):
                 # or ABCs.
                 return "I annotated with a generic collection"
             _.__annotations__ = dict(arg=typing.Iterable[str])
+            i.register(_)
         self.assertTrue(str(exc.exception).startswith(
             "Invalid annotation for 'arg'."
         ))

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -43,6 +43,9 @@ else:
 del _prefix
 
 
+str = type("")
+
+
 class TestSingleDispatch(unittest.TestCase):
     def test_simple_overloads(self):
         @functools.singledispatch
@@ -598,7 +601,7 @@ class TestSingleDispatch(unittest.TestCase):
             @t.register(int)
             def _(self, arg):
                 self.arg = "int"
-            @t.register(six.text_type)
+            @t.register(str)
             def _(self, arg):
                 self.arg = "str"
         a = A()
@@ -626,10 +629,10 @@ class TestSingleDispatch(unittest.TestCase):
             @staticmethod
             def _(arg):
                 return isinstance(arg, int)
-            @t.register(six.text_type)
+            @t.register(str)
             @staticmethod
             def _(arg):
-                return isinstance(arg, six.text_type)
+                return isinstance(arg, str)
         a = A()
 
         self.assertTrue(A.t(0))
@@ -649,7 +652,7 @@ class TestSingleDispatch(unittest.TestCase):
             @classmethod
             def _(cls, arg):
                 return cls("int")
-            @t.register(six.text_type)
+            @t.register(str)
             @classmethod
             def _(cls, arg):
                 return cls("str")
@@ -672,7 +675,7 @@ class TestSingleDispatch(unittest.TestCase):
         @classmethod
         def _(cls, arg):
             return cls("int")
-        @A.t.register(six.text_type)
+        @A.t.register(str)
         @classmethod
         def _(cls, arg):
             return cls("str")
@@ -706,7 +709,7 @@ class TestSingleDispatch(unittest.TestCase):
             # def _(self, arg: str):
             def _(self, arg):
                 return "str"
-            _.__annotations__ = dict(arg=six.text_type)
+            _.__annotations__ = dict(arg=str)
             t.register(_)
 
         a = A()
@@ -756,7 +759,7 @@ class TestSingleDispatch(unittest.TestCase):
             "Invalid annotation for 'arg'."
         ))
         self.assertTrue(str(exc.exception).endswith(
-            'typing.Iterable[str] is not a class.'
+            'typing.Iterable[' + str.__name__ + '] is not a class.'
         ))
 
     def test_invalid_positional_argument(self):

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -724,10 +724,6 @@ class TestSingleDispatch(unittest.TestCase):
             ". Use either `@register(some_class)` or plain `@register` on an "
             "annotated function."
         )
-        if six.PY2:
-            msg_body = "<function _"
-        else:
-            msg_body = "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
         @functools.singledispatch
         def i(arg):
             return "base"
@@ -741,7 +737,10 @@ class TestSingleDispatch(unittest.TestCase):
             @i.register
             def _(arg):
                 return "I forgot to annotate"
-        self.assertTrue(str(exc.exception).startswith(msg_prefix + msg_body))
+        scope = "TestSingleDispatch.test_invalid_registrations.<locals>." * six.PY3
+        self.assertTrue(str(exc.exception).startswith(msg_prefix +
+            "<function " + scope + "_"
+        ))
         self.assertTrue(str(exc.exception).endswith(msg_suffix))
 
         with self.assertRaises(TypeError) as exc:

--- a/test_singledispatch.py
+++ b/test_singledispatch.py
@@ -6,12 +6,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import abc
 import sys
 import collections
 import decimal
 from itertools import permutations
 import singledispatch as functools
 from singledispatch.helpers import Support
+import typing
 try:
     from collections import ChainMap
 except ImportError:
@@ -586,6 +588,180 @@ class TestSingleDispatch(unittest.TestCase):
             def __eq__(self, other):
                 return self.arg == other
         self.assertEqual(i("str"), "str")
+
+    def test_method_register(self):
+        class A:
+            @functools.singledispatchmethod
+            def t(self, arg):
+                self.arg = "base"
+            @t.register(int)
+            def _(self, arg):
+                self.arg = "int"
+            @t.register(str)
+            def _(self, arg):
+                self.arg = "str"
+        a = A()
+
+        a.t(0)
+        self.assertEqual(a.arg, "int")
+        aa = A()
+        self.assertFalse(hasattr(aa, 'arg'))
+        a.t('')
+        self.assertEqual(a.arg, "str")
+        aa = A()
+        self.assertFalse(hasattr(aa, 'arg'))
+        a.t(0.0)
+        self.assertEqual(a.arg, "base")
+        aa = A()
+        self.assertFalse(hasattr(aa, 'arg'))
+
+    def test_staticmethod_register(self):
+        class A:
+            @functools.singledispatchmethod
+            @staticmethod
+            def t(arg):
+                return arg
+            @t.register(int)
+            @staticmethod
+            def _(arg):
+                return isinstance(arg, int)
+            @t.register(str)
+            @staticmethod
+            def _(arg):
+                return isinstance(arg, str)
+        a = A()
+
+        self.assertTrue(A.t(0))
+        self.assertTrue(A.t(''))
+        self.assertEqual(A.t(0.0), 0.0)
+
+    def test_classmethod_register(self):
+        class A:
+            def __init__(self, arg):
+                self.arg = arg
+
+            @functools.singledispatchmethod
+            @classmethod
+            def t(cls, arg):
+                return cls("base")
+            @t.register(int)
+            @classmethod
+            def _(cls, arg):
+                return cls("int")
+            @t.register(str)
+            @classmethod
+            def _(cls, arg):
+                return cls("str")
+
+        self.assertEqual(A.t(0).arg, "int")
+        self.assertEqual(A.t('').arg, "str")
+        self.assertEqual(A.t(0.0).arg, "base")
+
+    def test_callable_register(self):
+        class A:
+            def __init__(self, arg):
+                self.arg = arg
+
+            @functools.singledispatchmethod
+            @classmethod
+            def t(cls, arg):
+                return cls("base")
+
+        @A.t.register(int)
+        @classmethod
+        def _(cls, arg):
+            return cls("int")
+        @A.t.register(str)
+        @classmethod
+        def _(cls, arg):
+            return cls("str")
+
+        self.assertEqual(A.t(0).arg, "int")
+        self.assertEqual(A.t('').arg, "str")
+        self.assertEqual(A.t(0.0).arg, "base")
+
+    def test_abstractmethod_register(self):
+        class Abstract(abc.ABCMeta):
+
+            @functools.singledispatchmethod
+            @abc.abstractmethod
+            def add(self, x, y):
+                pass
+
+        self.assertTrue(Abstract.add.__isabstractmethod__)
+
+    def test_type_ann_register(self):
+        class A:
+            @functools.singledispatchmethod
+            def t(self, arg):
+                return "base"
+            # @t.register
+            # def _(self, arg: int):
+            def _(self, arg):
+                return "int"
+            _.__annotations__ = dict(arg=int)
+            t.register(_)
+            # @t.register
+            # def _(self, arg: str):
+            def _(self, arg):
+                return "str"
+            _.__annotations__ = dict(arg=str)
+            t.register(_)
+
+        a = A()
+
+        self.assertEqual(a.t(0), "int")
+        self.assertEqual(a.t(''), "str")
+        self.assertEqual(a.t(0.0), "base")
+
+    def test_invalid_registrations(self):
+        msg_prefix = "Invalid first argument to `register()`: "
+        msg_suffix = (
+            ". Use either `@register(some_class)` or plain `@register` on an "
+            "annotated function."
+        )
+        @functools.singledispatch
+        def i(arg):
+            return "base"
+        with self.assertRaises(TypeError) as exc:
+            @i.register(42)
+            def _(arg):
+                return "I annotated with a non-type"
+        self.assertTrue(str(exc.exception).startswith(msg_prefix + "42"))
+        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+        with self.assertRaises(TypeError) as exc:
+            @i.register
+            def _(arg):
+                return "I forgot to annotate"
+        self.assertTrue(str(exc.exception).startswith(msg_prefix +
+            "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
+        ))
+        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+
+        with self.assertRaises(TypeError) as exc:
+            # @i.register
+            # def _(arg: typing.Iterable[str]):
+            def _(arg):
+                # At runtime, dispatching on generics is impossible.
+                # When registering implementations with singledispatch, avoid
+                # types from `typing`. Instead, annotate with regular types
+                # or ABCs.
+                return "I annotated with a generic collection"
+            _.__annotations__ = dict(arg=typing.Iterable[str])
+        self.assertTrue(str(exc.exception).startswith(
+            "Invalid annotation for 'arg'."
+        ))
+        self.assertTrue(str(exc.exception).endswith(
+            'typing.Iterable[str] is not a class.'
+        ))
+
+    def test_invalid_positional_argument(self):
+        @functools.singledispatch
+        def f(*args):
+            pass
+        msg = 'f requires at least 1 positional argument'
+        with self.assertRaisesRegex(TypeError, msg):
+            f()
 
 
 def _mro_compat(classes):


### PR DESCRIPTION
This PR adds support for Python 3.8's [singledispatchmethod](https://docs.python.org/3/library/functools.html#functools.singledispatchmethod) and as a side-effect also improves validating which annotations may be used for registering implementation funcions.